### PR TITLE
Convert `news` to `_posts` format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 
 In order to develop, make sure you have Jekyll installed and execute `jekyll serve -w`. The development server will run at `localhost:4000` and will regenerate automatically if source changes.
 
+## Blogging
+
+There is a `Rakefile` ([original](https://github.com/plusjade/jekyll-bootstrap/blob/master/Rakefile)) that makes it easy to generate posts. Simply `rake post title="First Post"`. You can pass other parameters, such as date or tags, if needed.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,309 @@
+require "rubygems"
+require 'rake'
+require 'yaml'
+require 'time'
+
+SOURCE = "."
+CONFIG = {
+  'version' => "0.3.0",
+  'themes' => File.join(SOURCE, "_includes", "themes"),
+  'layouts' => File.join(SOURCE, "_layouts"),
+  'posts' => File.join(SOURCE, "_posts"),
+  'post_ext' => "md",
+  'theme_package_version' => "0.1.0"
+}
+
+# Path configuration helper
+module JB
+  class Path
+    SOURCE = "."
+    Paths = {
+      :layouts => "_layouts",
+      :themes => "_includes/themes",
+      :theme_assets => "assets/themes",
+      :theme_packages => "_theme_packages",
+      :posts => "_posts"
+    }
+
+    def self.base
+      SOURCE
+    end
+
+    # build a path relative to configured path settings.
+    def self.build(path, opts = {})
+      opts[:root] ||= SOURCE
+      path = "#{opts[:root]}/#{Paths[path.to_sym]}/#{opts[:node]}".split("/")
+      path.compact!
+      File.__send__ :join, path
+    end
+
+  end #Path
+end #JB
+
+# Usage: rake post title="A Title" [date="2012-02-09"] [tags=[tag1,tag2]] [category="category"]
+desc "Begin a new post in #{CONFIG['posts']}"
+task :post do
+  abort("rake aborted: '#{CONFIG['posts']}' directory not found.") unless FileTest.directory?(CONFIG['posts'])
+  title = ENV["title"] || "new-post"
+  tags = ENV["tags"] || "[]"
+  category = ENV["category"] || ""
+  category = "\"#{category.gsub(/-/,' ')}\"" if !category.empty?
+  slug = title.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
+  begin
+    date = (ENV['date'] ? Time.parse(ENV['date']) : Time.now).strftime('%Y-%m-%d')
+  rescue => e
+    puts "Error - date format must be YYYY-MM-DD, please check you typed it correctly!"
+    exit -1
+  end
+  filename = File.join(CONFIG['posts'], "#{date}-#{slug}.#{CONFIG['post_ext']}")
+  if File.exist?(filename)
+    abort("rake aborted!") if ask("#{filename} already exists. Do you want to overwrite?", ['y', 'n']) == 'n'
+  end
+
+  puts "Creating new post: #{filename}"
+  open(filename, 'w') do |post|
+    post.puts "---"
+    post.puts "layout: post"
+    post.puts "title: \"#{title.gsub(/-/,' ')}\""
+    post.puts 'description: ""'
+    post.puts "category: #{category}"
+    post.puts "tags: #{tags}"
+    post.puts "---"
+  end
+end # task :post
+
+# Usage: rake page name="about.html"
+# You can also specify a sub-directory path.
+# If you don't specify a file extention we create an index.html at the path specified
+desc "Create a new page."
+task :page do
+  name = ENV["name"] || "new-page.md"
+  filename = File.join(SOURCE, "#{name}")
+  filename = File.join(filename, "index.html") if File.extname(filename) == ""
+  title = File.basename(filename, File.extname(filename)).gsub(/[\W\_]/, " ").gsub(/\b\w/){$&.upcase}
+  if File.exist?(filename)
+    abort("rake aborted!") if ask("#{filename} already exists. Do you want to overwrite?", ['y', 'n']) == 'n'
+  end
+
+  mkdir_p File.dirname(filename)
+  puts "Creating new page: #{filename}"
+  open(filename, 'w') do |post|
+    post.puts "---"
+    post.puts "layout: page"
+    post.puts "title: \"#{title}\""
+    post.puts 'description: ""'
+    post.puts "---"
+  end
+end # task :page
+
+desc "Launch preview environment"
+task :preview do
+  system "jekyll serve -w"
+end # task :preview
+
+# Public: Alias - Maintains backwards compatability for theme switching.
+task :switch_theme => "theme:switch"
+
+namespace :theme do
+
+  # Public: Switch from one theme to another for your blog.
+  #
+  # name - String, Required. name of the theme you want to switch to.
+  #        The theme must be installed into your JB framework.
+  #
+  # Examples
+  #
+  #   rake theme:switch name="the-program"
+  #
+  # Returns Success/failure messages.
+  desc "Switch between Jekyll-bootstrap themes."
+  task :switch do
+    theme_name = ENV["name"].to_s
+    theme_path = File.join(CONFIG['themes'], theme_name)
+    settings_file = File.join(theme_path, "settings.yml")
+    non_layout_files = ["settings.yml"]
+
+    abort("rake aborted: name cannot be blank") if theme_name.empty?
+    abort("rake aborted: '#{theme_path}' directory not found.") unless FileTest.directory?(theme_path)
+    abort("rake aborted: '#{CONFIG['layouts']}' directory not found.") unless FileTest.directory?(CONFIG['layouts'])
+
+    Dir.glob("#{theme_path}/*") do |filename|
+      next if non_layout_files.include?(File.basename(filename).downcase)
+      puts "Generating '#{theme_name}' layout: #{File.basename(filename)}"
+
+      open(File.join(CONFIG['layouts'], File.basename(filename)), 'w') do |page|
+        if File.basename(filename, ".html").downcase == "default"
+          page.puts "---"
+          page.puts File.read(settings_file) if File.exist?(settings_file)
+          page.puts "---"
+        else
+          page.puts "---"
+          page.puts "layout: default"
+          page.puts "---"
+        end
+        page.puts "{% include JB/setup %}"
+        page.puts "{% include themes/#{theme_name}/#{File.basename(filename)} %}"
+      end
+    end
+
+    puts "=> Theme successfully switched!"
+    puts "=> Reload your web-page to check it out =)"
+  end # task :switch
+
+  # Public: Install a theme using the theme packager.
+  # Version 0.1.0 simple 1:1 file matching.
+  #
+  # git  - String, Optional path to the git repository of the theme to be installed.
+  # name - String, Optional name of the theme you want to install.
+  #        Passing name requires that the theme package already exist.
+  #
+  # Examples
+  #
+  #   rake theme:install git="https://github.com/jekyllbootstrap/theme-twitter.git"
+  #   rake theme:install name="cool-theme"
+  #
+  # Returns Success/failure messages.
+  desc "Install theme"
+  task :install do
+    if ENV["git"]
+      manifest = theme_from_git_url(ENV["git"])
+      name = manifest["name"]
+    else
+      name = ENV["name"].to_s.downcase
+    end
+
+    packaged_theme_path = JB::Path.build(:theme_packages, :node => name)
+
+    abort("rake aborted!
+      => ERROR: 'name' cannot be blank") if name.empty?
+    abort("rake aborted!
+      => ERROR: '#{packaged_theme_path}' directory not found.
+      => Installable themes can be added via git. You can find some here: http://github.com/jekyllbootstrap
+      => To download+install run: `rake theme:install git='[PUBLIC-CLONE-URL]'`
+      => example : rake theme:install git='git@github.com:jekyllbootstrap/theme-the-program.git'
+    ") unless FileTest.directory?(packaged_theme_path)
+
+    manifest = verify_manifest(packaged_theme_path)
+
+    # Get relative paths to packaged theme files
+    # Exclude directories as they'll be recursively created. Exclude meta-data files.
+    packaged_theme_files = []
+    FileUtils.cd(packaged_theme_path) {
+      Dir.glob("**/*.*") { |f|
+        next if ( FileTest.directory?(f) || f =~ /^(manifest|readme|packager)/i )
+        packaged_theme_files << f
+      }
+    }
+
+    # Mirror each file into the framework making sure to prompt if already exists.
+    packaged_theme_files.each do |filename|
+      file_install_path = File.join(JB::Path.base, filename)
+      if File.exist? file_install_path and ask("#{file_install_path} already exists. Do you want to overwrite?", ['y', 'n']) == 'n'
+        next
+      else
+        mkdir_p File.dirname(file_install_path)
+        cp_r File.join(packaged_theme_path, filename), file_install_path
+      end
+    end
+
+    puts "=> #{name} theme has been installed!"
+    puts "=> ---"
+    if ask("=> Want to switch themes now?", ['y', 'n']) == 'y'
+      system("rake switch_theme name='#{name}'")
+    end
+  end
+
+  # Public: Package a theme using the theme packager.
+  # The theme must be structured using valid JB API.
+  # In other words packaging is essentially the reverse of installing.
+  #
+  # name - String, Required name of the theme you want to package.
+  #
+  # Examples
+  #
+  #   rake theme:package name="twitter"
+  #
+  # Returns Success/failure messages.
+  desc "Package theme"
+  task :package do
+    name = ENV["name"].to_s.downcase
+    theme_path = JB::Path.build(:themes, :node => name)
+    asset_path = JB::Path.build(:theme_assets, :node => name)
+
+    abort("rake aborted: name cannot be blank") if name.empty?
+    abort("rake aborted: '#{theme_path}' directory not found.") unless FileTest.directory?(theme_path)
+    abort("rake aborted: '#{asset_path}' directory not found.") unless FileTest.directory?(asset_path)
+
+    ## Mirror theme's template directory (_includes)
+    packaged_theme_path = JB::Path.build(:themes, :root => JB::Path.build(:theme_packages, :node => name))
+    mkdir_p packaged_theme_path
+    cp_r theme_path, packaged_theme_path
+
+    ## Mirror theme's asset directory
+    packaged_theme_assets_path = JB::Path.build(:theme_assets, :root => JB::Path.build(:theme_packages, :node => name))
+    mkdir_p packaged_theme_assets_path
+    cp_r asset_path, packaged_theme_assets_path
+
+    ## Log packager version
+    packager = {"packager" => {"version" => CONFIG["theme_package_version"].to_s } }
+    open(JB::Path.build(:theme_packages, :node => "#{name}/packager.yml"), "w") do |page|
+      page.puts packager.to_yaml
+    end
+
+    puts "=> '#{name}' theme is packaged and available at: #{JB::Path.build(:theme_packages, :node => name)}"
+  end
+
+end # end namespace :theme
+
+# Internal: Download and process a theme from a git url.
+# Notice we don't know the name of the theme until we look it up in the manifest.
+# So we'll have to change the folder name once we get the name.
+#
+# url - String, Required url to git repository.
+#
+# Returns theme manifest hash
+def theme_from_git_url(url)
+  tmp_path = JB::Path.build(:theme_packages, :node => "_tmp")
+  abort("rake aborted: system call to git clone failed") if !system("git clone #{url} #{tmp_path}")
+  manifest = verify_manifest(tmp_path)
+  new_path = JB::Path.build(:theme_packages, :node => manifest["name"])
+  if File.exist?(new_path) && ask("=> #{new_path} theme package already exists. Override?", ['y', 'n']) == 'n'
+    remove_dir(tmp_path)
+    abort("rake aborted: '#{manifest["name"]}' already exists as theme package.")
+  end
+
+  remove_dir(new_path) if File.exist?(new_path)
+  mv(tmp_path, new_path)
+  manifest
+end
+
+# Internal: Process theme package manifest file.
+#
+# theme_path - String, Required. File path to theme package.
+#
+# Returns theme manifest hash
+def verify_manifest(theme_path)
+  manifest_path = File.join(theme_path, "manifest.yml")
+  manifest_file = File.open( manifest_path )
+  abort("rake aborted: repo must contain valid manifest.yml") unless File.exist? manifest_file
+  manifest = YAML.load( manifest_file )
+  manifest_file.close
+  manifest
+end
+
+def ask(message, valid_options)
+  if valid_options
+    answer = get_stdin("#{message} #{valid_options.to_s.gsub(/"/, '').gsub(/, /,'/')} ") while !valid_options.include?(answer)
+  else
+    answer = get_stdin(message)
+  end
+  answer
+end
+
+def get_stdin(message)
+  print message
+  STDIN.gets.chomp
+end
+
+#Load custom rake scripts
+Dir['_rake/*.rake'].each { |r| load r }

--- a/_layouts/layout.html
+++ b/_layouts/layout.html
@@ -6,11 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <link href='https://fonts.googleapis.com/css?family=Architects+Daughter' rel='stylesheet' type='text/css'>
     <link href='http://fonts.googleapis.com/css?family=Ubuntu:700italic' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen" />
-    <link rel="stylesheet" type="text/css" href="stylesheets/pygment_trac.css" media="screen" />
-    <link rel="stylesheet" type="text/css" href="stylesheets/print.css" media="print" />
+    <link rel="stylesheet" type="text/css" href="/stylesheets/stylesheet.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="/stylesheets/pygment_trac.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="/stylesheets/print.css" media="print" />
     <link rel="shortcut icon" href="/favicon.ico" />
-    <script type="text/javascript" src="javascripts/jquery-2.1.1.min.js"></script>
+    <script type="text/javascript" src="/javascripts/jquery-2.1.1.min.js"></script>
 
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -102,9 +102,9 @@
           Sipola</a>. Both of us are members
           of <a href="http://koodilehto.fi">Koodilehto co-op.</a></p>
 
-          <p><a href="http://www.koodilehto.fi/"><img class="logo" src="images/logos/koodilehto_logo_100x114.png" title="Koodilehto's logo"/></a></p>
+          <p><a href="http://www.koodilehto.fi/"><img class="logo" src="/images/logos/koodilehto_logo_100x114.png" title="Koodilehto's logo"/></a></p>
           
-          <p>Digita broadcasts Kryptoradio in Finland. <a href="http://www.digita.fi/"><img class="logo" src="images/logos/digita_valk_pysty_rgb.jpg" title="Digita's logo" /></a></p>
+          <p>Digita broadcasts Kryptoradio in Finland. <a href="http://www.digita.fi/"><img class="logo" src="/images/logos/digita_valk_pysty_rgb.jpg" title="Digita's logo" /></a></p>
 
           <p>Site layout is based on Architect theme
           by <a href="https://twitter.com/jasonlong">Jason
@@ -121,7 +121,7 @@
 	  </p>
 	  {% endif %}
       <div id='cen'>
-        <img src="images/bitcoin_address.png" title="QR code of our bitcoin address" />
+        <img src="/images/bitcoin_address.png" title="QR code of our bitcoin address" />
       </div>
         </aside>
       </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,8 @@
+---
+layout: layout
+---
+
+<h2>{{ page.title }}</h2>
+
+{{ content }}
+

--- a/_posts/2014-08-31-kryptoradio-pilot-broadcast-to-launch-tomorrow.md
+++ b/_posts/2014-08-31-kryptoradio-pilot-broadcast-to-launch-tomorrow.md
@@ -1,0 +1,8 @@
+---
+layout: post
+title: "Kryptoradio pilot broadcast to launch tomorrow"
+description: ""
+tags: []
+---
+
+Bitcoin pilot broadcast will start on 2014-09-01. It will last until 2014-10-31 and cover most of Finland.

--- a/atom.xml
+++ b/atom.xml
@@ -1,0 +1,31 @@
+---
+layout: nil
+---
+<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+ 
+  <title>Kryptoradio</title>
+  <link href="http://www.kryptorad.io/"/>
+  <link type="application/atom+xml" rel="self" href="http://www.kryptorad.io/atom.xml"/>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>http://www.kryptorad.io/</id>
+  <author>
+    <name>Kryptoradio</name>
+    <email>TODO</email>
+  </author>
+
+  {% for post in site.posts %}
+  <entry>
+    <id>http://www.kryptorad.io/{{ post.id }}</id>
+    <link type="text/html" rel="alternate" href="http://www.kryptorad.io{{ post.url }}"/>
+    <title>{{ post.title }}</title>
+    <updated>{{ post.date | date_to_xmlschema }}</updated>
+    <author>
+      <name>Geek Collision</name>
+      <uri>http://www.geekcollision.org/</uri>
+    </author>
+    <content type="html">{{ post.content | xml_escape }}</content>
+  </entry>
+  {% endfor %}
+ 
+</feed>

--- a/news.html
+++ b/news.html
@@ -4,9 +4,8 @@ layout: layout
 
 <h2 id="general">News</h2>
 
-<h3>Kryptoradio pilot broadcast to launch tomorrow</h3>
-
-<p id="date">2014-08-31</p>
-
-<p>Bitcoin pilot broadcast will start on 2014-09-01. It will last until 2014-10-31 and cover most of Finland. </p>
-
+{% for post in site.posts %}
+    <h3>{{ post.title }}</h3>
+    <div class="date">{{ post.date | date_to_string }}</div>
+    {{ post.content }}
+{% endfor %}


### PR DESCRIPTION
Features:
- Post listing at `/news`
- RSS through atom (`/atom.xml`)
- Individual posts (<date>/<post slug>). RSS points at these.

I changed base layout resources to point at the site root. This was done to keep `post` layout simple (derived from base).

It is possible to generate new posts using `rake post title="First Post"`. Obviously you should have `rake` installed for this to work.
